### PR TITLE
Improve long dropdown menu lists

### DIFF
--- a/p/themes/Origine/origine.css
+++ b/p/themes/Origine/origine.css
@@ -330,6 +330,8 @@ a.btn {
 	box-shadow: 3px 3px 3px #ddd;
 	font-size: 0.8rem;
 	text-align: left;
+	max-height: 60vh;
+	overflow: hidden auto;
 }
 .dropdown-menu::after {
 	content: "";


### PR DESCRIPTION
### Issue:
Dropdown menus with lots of entries were a bit difficult to use …
I was only able to see either the bottom of the labels-list or the article and not both …
And I was unable to close the labels menu on my Phone after adding more than 12 labels.

### Changes:
I set the max height to 60% of Vieport-height and enabled vertical scrolling … in the theme I use …

### To Further Improve:
- Maybe similar changes to other themes are needed.
- On my (windows) phone i still can't add all labels because i cant scroll the menu … but at least i can close it again without reload …
Works ok on my Android …